### PR TITLE
remove randomly failing script from test list

### DIFF
--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -8,7 +8,6 @@ function runScript(path) {
 t.test('exercises/section1/order/first.js', async t => runScript(t.name));
 t.test('exercises/section1/order/second.js', async t => runScript(t.name));
 
-t.test('exercises/section2/caching-promises/broken.js', async t => runScript(t.name));
 t.test('exercises/section2/caching-promises/fixed.js', async t => runScript(t.name));
 
 t.test('exercises/section2/event-handler-error-handling/better.js', async t => runScript(t.name));


### PR DESCRIPTION
I excluded `broken.js` script from the smoke tests list. This script is failing randomly by design - part of the exercise.

Fixes #30 